### PR TITLE
20200409 barebones item support

### DIFF
--- a/example/data/world/sammatti.zone
+++ b/example/data/world/sammatti.zone
@@ -74,3 +74,18 @@ characters "villager" {
   name = "Villager"
   description = "A villager of Sammatti."
 }
+
+items "sword" {
+  name = "Sword of Destiny"
+  description = "A radiant sword"
+}
+
+room_items "town_square" {
+  room_id = rooms.town_square.id
+
+  items = [
+    {
+      id = items.sword.id
+    }
+  ]
+}

--- a/example/lib/kantele/character/views/look_view.ex
+++ b/example/lib/kantele/character/views/look_view.ex
@@ -11,6 +11,7 @@ defmodule Kantele.Character.LookView do
 
     You see:
     <%= render("_characters", %{characters: characters}) %>
+    <%= render("_items", %{items: room.items}) %>
     """
   end
 
@@ -42,5 +43,15 @@ defmodule Kantele.Character.LookView do
 
   def render("_character", %{character: character}) do
     ~i(- #{white()}#{character.name}#{reset()})
+  end
+
+  def render("_items", %{items: items}) do
+    items
+    |> Enum.map(&render("_item", %{item: &1}))
+    |> View.join("\n")
+  end
+
+  def render("_item", %{item: item}) do
+    ~i(- #{white()}#{item.name}#{reset()})
   end
 end

--- a/example/lib/kantele/item.ex
+++ b/example/lib/kantele/item.ex
@@ -1,0 +1,14 @@
+defmodule Kantele.Item do
+  @moduledoc """
+  Item struct
+
+  Common data that all items will have
+  """
+
+  defstruct [:id, :room_id, :name, :description, meta: %{}]
+
+  @doc """
+  Reduce the size of the meta map before sending in an event
+  """
+  @callback trim_meta(meta :: map()) :: map()
+end

--- a/example/lib/kantele/world.ex
+++ b/example/lib/kantele/world.ex
@@ -8,7 +8,7 @@ defmodule Kantele.World do
   alias Kantele.World.Cache
   alias Kantele.World.Loader
 
-  defstruct zones: [], rooms: [], characters: []
+  defstruct zones: [], rooms: [], characters: [], items: []
 
   @doc """
   Dereference a world variable reference

--- a/lib/kalevala/world/room.ex
+++ b/lib/kalevala/world/room.ex
@@ -5,7 +5,7 @@ defmodule Kalevala.World.Room.Context do
 
   @type t() :: %__MODULE__{}
 
-  defstruct [:data, assigns: %{}, characters: [], events: [], lines: []]
+  defstruct [:data, assigns: %{}, characters: [], items: [], events: [], lines: []]
 
   defp push(context, to_pid, event = %Kalevala.Character.Conn.Event{}, _newline) do
     Map.put(context, :lines, context.lines ++ [{to_pid, event}])
@@ -174,7 +174,8 @@ defmodule Kalevala.World.Room do
     :name,
     :description,
     exits: [],
-    features: []
+    features: [],
+    items: []
   ]
 
   @type t() :: %__MODULE__{}

--- a/lib/kalevala/world/zone.ex
+++ b/lib/kalevala/world/zone.ex
@@ -10,7 +10,7 @@ defmodule Kalevala.World.Zone do
   alias Kalevala.Event
   alias Kalevala.World.Zone.Movement
 
-  defstruct [:id, :name, characters: [], rooms: []]
+  defstruct [:id, :name, characters: [], rooms: [], items: []]
 
   @type t() :: %__MODULE__{}
 


### PR DESCRIPTION
This clearly leaves a lot to be desired but perhaps it's a start. Initial thoughts:

1) having room_id be a member of the item struct seems a bit off, since an item will not always be sitting in a room. I haven't thought much about the implications of this yet. Do we need to have different structures for "item-in-a-room" vs "item-in-a-characters-inventory"? Or is it okay to just have room_id as null sometimes
2) similarly, the item's ID probably shouldn't be tied to the room it was spawned in, or perhaps that's fine until it's picked up at which point the ID should be changed or something?
3) i didn't think too critically about whether there would be any value to tracking the items at the zone and world level, i just copied what was being done for characters. In retrospect this probably isn't necessary?